### PR TITLE
Add support for resourcePath

### DIFF
--- a/lib/swagger-dsl.coffee
+++ b/lib/swagger-dsl.coffee
@@ -228,6 +228,10 @@ init = (self,options)->
   # **base(path)** sets the document's `basePath` property.
   this.base = this.basepath = this.base_path = this.basePath = (path)=>
     rest.basePath = path
+  
+  # **resourcePath(path)** sets the document's `resourcePath` property.
+  this.resourcePath = this.resource_path = this.resourcepath = (path)=>
+    rest.resourcePath = path
 
 
   # For "convenience", we add variables containing the string version of


### PR DESCRIPTION
Add support for resourcePath which allows for headings besides "default" in swagger-ui.  If using the dsl to generate multiple json files mapped by a master "api-docs.json" file, this should give each file its own heading rather than all the endpoints living under "default".  basePath doesn't appear to give the same capabilities.
